### PR TITLE
評価一覧・ピア評価結果のヘッダー固定表示化および1人グループの貢献点付与バグ修正

### DIFF
--- a/school_management/templates/school_management/class_evaluation.html
+++ b/school_management/templates/school_management/class_evaluation.html
@@ -197,8 +197,9 @@ body { background-color: #f8fafc; }
 
     /* テーブルコンテナ（スクロール用） */
     .table-container {
-        overflow-x: auto;
-        max-height: 80vh;
+        overflow: auto;
+        max-height: calc(100vh - 280px);
+        min-height: 350px;
         border-radius: 8px;
         box-shadow: 0 2px 4px rgba(0,0,0,0.05);
         position: relative;
@@ -766,7 +767,7 @@ window.addEventListener('beforeprint', function() {
 });
 
 window.addEventListener('afterprint', function() {
-    document.querySelector('.table-container').style.maxHeight = '80vh';
+    document.querySelector('.table-container').style.maxHeight = 'calc(100vh - 280px)';
     document.querySelector('.table-container').style.overflow = 'auto';
 });
 

--- a/school_management/templates/school_management/peer_evaluation_results.html
+++ b/school_management/templates/school_management/peer_evaluation_results.html
@@ -15,8 +15,9 @@
 <style>
     /* --- Base Styles from class_evaluation.html --- */
     .table-container {
-        overflow-x: auto;
-        max-height: 80vh;
+        overflow: auto;
+        max-height: calc(100vh - 280px);
+        min-height: 350px;
         border-radius: 8px;
         box-shadow: 0 2px 4px rgba(0,0,0,0.05);
         position: relative;
@@ -101,6 +102,21 @@
     .evaluation-table thead th.name-col {
         z-index: 12;
         background-color: #f8f9fa;
+    }
+
+    /* 2段ヘッダー用の調整 */
+    .evaluation-table.mode-detail thead tr:first-child th {
+        height: 50px; /* 1行目の高さ固定 */
+    }
+    .evaluation-table.mode-detail thead tr:last-child th {
+        position: sticky;
+        top: 50px; /* 1行目の高さ分下げる */
+        z-index: 9;
+        height: 30px;
+        padding: 4px;
+        font-weight: normal;
+        font-size: 0.85em;
+        background-color: #f1f3f5;
     }
 
     /* --- Dynamic detail columns --- */
@@ -412,7 +428,6 @@
                             {% if view_mode == 'simple' %}
                             <p class="m-3 text-muted small">簡易表示では提出の有無のみ確認できます。詳細な提出内容を確認するには「詳細」表示に切り替えてください。</p>
                             {% endif %}
-                            <div class="table-responsive">
                             <table class="evaluation-table mode-{{ view_mode }}">
                             <thead>
                                 <tr>
@@ -527,7 +542,6 @@
                                 {% endfor %}
                             </tbody>
                             </table>
-                        </div>
                         {% endif %}
                     {% else %}
                     <div class="text-center py-4">

--- a/school_management/tests/test_peer_eval_logic.py
+++ b/school_management/tests/test_peer_eval_logic.py
@@ -209,3 +209,27 @@ class PeerEvalAggregateLogicTests(TestCase):
         self.assertEqual(history_a2[0]['contrib'], 10)
         self.assertEqual(history_a2[0]['vote'], 5)
         self.assertEqual(history_a2[0]['total'], 15)
+
+    def test_aggregate_member_scores_one_person_group(self):
+        """1人グループの集計テスト: 他者評価が存在しないため、貢献ポイントは0点になること"""
+        # 1名のみのグループDを作成
+        group_d = Group.objects.create(lesson_session=self.session, group_number=4)
+        student_d1 = Student.objects.create(full_name="学生D1", email="d1@test.com", role="student")
+        GroupMember.objects.create(group=group_d, student=student_d1)
+        
+        # 学生D1が他グループを評価するデータを追加（フォーム送信した状態）
+        PeerEvaluation.objects.create(
+            lesson_session=self.session, student=student_d1, evaluator_group=group_d, evaluator_token=uuid.uuid4(),
+            response_json={"group_members_eval": [], "other_group_eval": []}
+        )
+        
+        self.session.peer_evaluation_status = LessonSession.PeerEvaluationStatus.CLOSED
+        self.session.save()
+        _aggregate_member_scores(self.session, self.settings)
+        
+        # 1人グループは貢献度評価オブジェクトが作成されない（＝0点）
+        evals = ContributionEvaluation.objects.filter(
+            peer_evaluation__lesson_session=self.session, 
+            evaluatee=student_d1
+        )
+        self.assertEqual(evals.count(), 0)

--- a/school_management/views/peer_eval/improved.py
+++ b/school_management/views/peer_eval/improved.py
@@ -782,10 +782,12 @@ def _aggregate_member_scores(lesson_session, pe_settings):
             continue
         
         # 内部ポイント集計: G-N点 (Nは与えられた順位)
-        internal_points = defaultdict(int)
-        for member in group_members:
-            internal_points[member.student_id] = 0
-        
+        # 現在のグループメンバーのみを対象にする（dictで固定し、途中でグループから
+        # 外れたメンバーへの投票が混入しないようにする。defaultdictだと
+        # 存在しないキー参照だけで自動的にエントリが作られてしまうため使わない）
+        internal_points = {member.student_id: 0 for member in group_members}
+        current_member_ids = set(internal_points.keys())
+
         group_evals = evals.filter(evaluator_group=group)
         for ev in group_evals:
             response = ev.response_json or {}
@@ -793,6 +795,9 @@ def _aggregate_member_scores(lesson_session, pe_settings):
                 member_id = _safe_int(entry.get('member_id'))
                 rank = _safe_int(entry.get('rank'))
                 if member_id is None or rank is None:
+                    continue
+                if member_id not in current_member_ids:
+                    # 集計時点でグループに所属していないメンバーへの投票は対象外
                     continue
                 internal_points[member_id] += (G - rank)
         

--- a/school_management/views/peer_eval/improved.py
+++ b/school_management/views/peer_eval/improved.py
@@ -771,7 +771,14 @@ def _aggregate_member_scores(lesson_session, pe_settings):
     for group in groups:
         group_members = list(GroupMember.objects.filter(group=group).select_related('student'))
         G = len(group_members)
-        if G == 0:
+        
+        # まず既存のContributionEvaluationを削除（このグループの集計分）
+        ContributionEvaluation.objects.filter(
+            peer_evaluation__lesson_session=lesson_session,
+            peer_evaluation__evaluator_group=group,
+        ).delete()
+        
+        if G <= 1:
             continue
         
         # 内部ポイント集計: G-N点 (Nは与えられた順位)
@@ -793,11 +800,6 @@ def _aggregate_member_scores(lesson_session, pe_settings):
         sorted_members = sorted(internal_points.items(), key=lambda x: x[1], reverse=True)
         
         # 同点（タイ）対応: 同じポイントのメンバーには同じ順位の点数を付与
-        # まず既存のContributionEvaluationを削除（このグループの集計分）
-        ContributionEvaluation.objects.filter(
-            peer_evaluation__lesson_session=lesson_session,
-            peer_evaluation__evaluator_group=group,
-        ).delete()
         
         # ダミーのピア評価を取得（集計結果保存用）
         aggregate_eval = group_evals.first()


### PR DESCRIPTION
### 概要

1人グループのピア評価貢献点の不具合を修正し、評価一覧およびピア評価結果画面のテーブルヘッダーをスクロール時も固定表示されるよう改善しました。

### 修正内容

* メンバーが1人のグループに対して、誤って「グループ内1位」の貢献点が付与される不具合を修正
* メンバー数が1人以下のグループでは、評価集計処理（`_aggregate_member_scores`）をスキップし、貢献点を0点として扱うよう変更
* 「評価一覧」および「ピア評価結果（提出状況）」のテーブルヘッダーをスクロール時も固定表示するよう改善